### PR TITLE
feat: allow this to be used as a nuxt module 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ yarn add nuxt-composition-api
 npm install nuxt-composition-api --save
 ```
 
+Install and enable the module in your `nuxt.config.js`
+
+```
+{
+  buildModules: [
+    'nuxt-composition-api'
+  ]
+}
+```
+
+
 You will now be able to access the following hooks:
 
 ### useFetch
@@ -91,6 +102,21 @@ export default defineComponent({
 ## Contributors
 
 Contributions are very welcome.
+
+
+Clone this repo 
+```
+git clone git@github.com:danielroe/nuxt-composition-api.git
+```
+
+Install dependencies and build project
+```
+yarn install
+
+yarn build
+```
+
+**Tip:** You can use `yarn link` to test the module locally with your nuxt project.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
   "sideEffects": false,
   "scripts": {
     "build": "yarn clean && yarn compile",
+    "build-tsc": "tsc",
+    "watch": "tsc --watch",
     "clean": "rm -rf lib/*",
     "compile": "rollup -c",
     "lint": "run-s lint:all:*",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,6 +21,7 @@ export default {
   external: [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),
+    'prop-types',
   ],
   plugins: [
     typescript({

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -34,7 +34,11 @@ async function callFetches(this: AugmentedComponentInstance) {
   const fetchesToCall = fetches.get(this)
   if (!fetchesToCall) return
   ;(this.$nuxt as any).nbFetching++
-  this.$fetchState = this.$fetchState || {}
+  this.$fetchState = this.$fetchState || {
+    error: null,
+    pending: false,
+    timestamp: 0,
+  }
   this.$fetchState.pending = true
   this.$fetchState.error = null
   this._hydrated = false
@@ -62,7 +66,11 @@ async function callFetches(this: AugmentedComponentInstance) {
 
 async function serverPrefetch(vm: AugmentedComponentInstance) {
   // Call and await on $fetch
-  vm.$fetchState = vm.$fetchState || {}
+  vm.$fetchState = vm.$fetchState || {
+    error: null,
+    pending: false,
+    timestamp: 0,
+  }
   try {
     await callFetches.call(vm)
   } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,16 @@
+import { resolve, join } from 'path'
 export { useFetch } from './fetch'
 export { withContext } from './context'
+import { Module } from '@nuxt/types'
+const libRoot = resolve(__dirname, '..')
+
+const compositionApiModule: Module<any> = function () {
+  const { dst } = this.addTemplate({
+    src: resolve(libRoot, 'lib', 'plugin.js'),
+    fileName: join('composition-api', 'plugin.js'),
+    options: {},
+  })
+  this.options.plugins.push(resolve(this.options.buildDir, dst))
+}
+
+export default compositionApiModule

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,4 @@
+import Vue from 'vue'
+import CompositionApi from '@vue/composition-api'
+
+Vue.use(CompositionApi)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,20 @@
 {
   "compilerOptions": {
-    "strict": true,
+    "strict": false,
     "sourceMap": true,
-    "target": "es2018",
-    "module": "esnext",
+    "target": "es2015",
+    "module": "commonjs",
     "lib": ["esnext", "dom"],
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "rootDir": "src",
-    "outDir": "lib",
+    /* Raise error on expressions and declarations with an implied 'any' */
+    "noImplicitAny": false,
+    "rootDir": "./src",
+    "outDir": "./lib",
     "declaration": true,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["@nuxt/types"]
+    "types": ["@types/node", "@nuxt/types"]
   },
   "exclude": ["node_modules", "lib", "test"]
 }


### PR DESCRIPTION
Hi,

the pr includes the following changes

✅ It's possible to use this repo as nuxt-module in your project
✅ `@vue/composition-api` will be available out of the box
✅ Some minor errors I experience while working with this module

❌ rollup configuration is broken
ℹ️tsc is used to create the build (updated tsconfig)
